### PR TITLE
clone_file copies only the first 4096 bytes of the source.

### DIFF
--- a/src/ct2md.py
+++ b/src/ct2md.py
@@ -163,11 +163,7 @@ def clone_file(src, dst):
         dstFolder = os.path.dirname(dst)
         if not os.path.exists(dstFolder):
             os.makedirs(dstFolder)
-
-        with open(src, 'rb') as flSrc:
-            with open(dst, 'wb') as flDst:
-                flDst.write(flSrc.read(4096))
-
+        open(dst, 'wb').write(open(src, 'rb').read())
     except OSError as e:
         error(e, " while clonning files", src,"=>",dst)
 


### PR DESCRIPTION

This commit fixes issue: https://github.com/mkamarin/ct2md/issues/1#issue-1868514769